### PR TITLE
fix: strip response body for HEAD and 304/204 responses

### DIFF
--- a/src/main/java/kotowari/restful/ResourceEngine.java
+++ b/src/main/java/kotowari/restful/ResourceEngine.java
@@ -45,7 +45,7 @@ import static kotowari.restful.decision.DecisionFactory.*;
  *   <li>405 and successful OPTIONS responses receive an {@code Allow} header
  *       (RFC 7231 §6.5.5, RFC 9110 §9.3.7).</li>
  *   <li>HEAD responses and 204/304 responses have their body cleared
- *       (RFC 7231 §4.3.2, RFC 7232 §4.1).</li>
+ *       (RFC 7231 §4.3.2, RFC 7232 §4.1, RFC 9110 §15.3.5).</li>
  * </ul>
  *
  * @author kawasima

--- a/src/main/java/kotowari/restful/ResourceEngine.java
+++ b/src/main/java/kotowari/restful/ResourceEngine.java
@@ -40,6 +40,14 @@ import static kotowari.restful.decision.DecisionFactory.*;
  *       Resource classes may override {@code @Decision(HANDLE_EXCEPTION)} to customize.</li>
  * </ul>
  *
+ * <p>Post-graph response fixups applied by {@link #run(Resource, HttpRequest)}:
+ * <ul>
+ *   <li>405 and successful OPTIONS responses receive an {@code Allow} header
+ *       (RFC 7231 §6.5.5, RFC 9110 §9.3.7).</li>
+ *   <li>HEAD responses and 204/304 responses have their body cleared
+ *       (RFC 7231 §4.3.2, RFC 7232 §4.1).</li>
+ * </ul>
+ *
  * @author kawasima
  */
 public class ResourceEngine {
@@ -95,6 +103,9 @@ public class ResourceEngine {
         int status = response.getStatus();
         if (status == 405 || ("OPTIONS".equalsIgnoreCase(request.getRequestMethod()) && status >= 200 && status < 300)) {
             response.getHeaders().put("Allow", allowHeaderValue(resource.getAllowedMethods()));
+        }
+        if ("HEAD".equalsIgnoreCase(request.getRequestMethod()) || status == 204 || status == 304) {
+            response.setBody(null);
         }
         return response;
     }

--- a/src/test/java/kotowari/restful/ResourceEngineTest.java
+++ b/src/test/java/kotowari/restful/ResourceEngineTest.java
@@ -90,4 +90,49 @@ class ResourceEngineTest {
         assertThat(response.getStatus()).isEqualTo(200);
         assertThat(response.getHeaders().get("Allow")).isEqualTo("GET, HEAD, POST");
     }
+
+    @Test
+    void headResponseHasNoBody() {
+        DefaultResource resource = new DefaultResource();
+        HttpRequest request = builder(new DefaultHttpRequest())
+                .set(HttpRequest::setRequestMethod, "HEAD")
+                .set(HttpRequest::setContentType, "application/json")
+                .set(HttpRequest::setHeaders, Headers.empty())
+                .build();
+
+        ApiResponse response = resourceEngine.run(resource, request);
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.getBody()).isNull();
+    }
+
+    @Test
+    void notModifiedResponseHasNoBody() {
+        // Resource that returns 304 by claiming nothing has been modified since
+        DefaultResource resource = new DefaultResource() {
+            @Override
+            public java.util.function.Function<kotowari.restful.data.RestContext, ?> getFunction(kotowari.restful.DecisionPoint point) {
+                if (point == kotowari.restful.DecisionPoint.IF_NONE_MATCH_EXISTS) {
+                    return ctx -> true;
+                }
+                if (point == kotowari.restful.DecisionPoint.IF_NONE_MATCH_STAR) {
+                    return ctx -> false;
+                }
+                if (point == kotowari.restful.DecisionPoint.ETAG_MATCHES_FOR_IF_NONE) {
+                    return ctx -> true;
+                }
+                return super.getFunction(point);
+            }
+        };
+        HttpRequest request = builder(new DefaultHttpRequest())
+                .set(HttpRequest::setRequestMethod, "GET")
+                .set(HttpRequest::setContentType, "application/json")
+                .set(HttpRequest::setHeaders, Headers.of("if-none-match", "\"abc\""))
+                .build();
+
+        ApiResponse response = resourceEngine.run(resource, request);
+
+        assertThat(response.getStatus()).isEqualTo(304);
+        assertThat(response.getBody()).isNull();
+    }
 }

--- a/src/test/java/kotowari/restful/ResourceEngineTest.java
+++ b/src/test/java/kotowari/restful/ResourceEngineTest.java
@@ -108,7 +108,8 @@ class ResourceEngineTest {
 
     @Test
     void notModifiedResponseHasNoBody() {
-        // Resource that returns 304 by claiming nothing has been modified since
+        // Resource that routes to 304 and also overrides HANDLE_NOT_MODIFIED to return a body,
+        // proving that the post-graph fixup strips it even when the handler would emit one.
         DefaultResource resource = new DefaultResource() {
             @Override
             public java.util.function.Function<kotowari.restful.data.RestContext, ?> getFunction(kotowari.restful.DecisionPoint point) {
@@ -120,6 +121,9 @@ class ResourceEngineTest {
                 }
                 if (point == kotowari.restful.DecisionPoint.ETAG_MATCHES_FOR_IF_NONE) {
                     return ctx -> true;
+                }
+                if (point == kotowari.restful.DecisionPoint.HANDLE_NOT_MODIFIED) {
+                    return ctx -> "should be stripped";
                 }
                 return super.getFunction(point);
             }
@@ -133,6 +137,34 @@ class ResourceEngineTest {
         ApiResponse response = resourceEngine.run(resource, request);
 
         assertThat(response.getStatus()).isEqualTo(304);
+        assertThat(response.getBody()).isNull();
+    }
+
+    @Test
+    void noContentResponseHasNoBody() {
+        // Resource that returns 204 by responding with entity=false after DELETE.
+        // HANDLE_NO_CONTENT is overridden to return a non-null body, proving the fixup strips it.
+        DefaultResource resource = new DefaultResource() {
+            @Override
+            public java.util.function.Function<kotowari.restful.data.RestContext, ?> getFunction(kotowari.restful.DecisionPoint point) {
+                if (point == kotowari.restful.DecisionPoint.METHOD_ALLOWED) {
+                    return DefaultResource.testRequestMethod("GET", "HEAD", "DELETE");
+                }
+                if (point == kotowari.restful.DecisionPoint.HANDLE_NO_CONTENT) {
+                    return ctx -> "should be stripped";
+                }
+                return super.getFunction(point);
+            }
+        };
+        HttpRequest request = builder(new DefaultHttpRequest())
+                .set(HttpRequest::setRequestMethod, "DELETE")
+                .set(HttpRequest::setContentType, "application/json")
+                .set(HttpRequest::setHeaders, Headers.empty())
+                .build();
+
+        ApiResponse response = resourceEngine.run(resource, request);
+
+        assertThat(response.getStatus()).isEqualTo(204);
         assertThat(response.getBody()).isNull();
     }
 }


### PR DESCRIPTION
## Summary

- HEAD responses have their body cleared after the decision graph, while headers (including any Content-Length set by upstream middleware) are preserved
- 204 No Content and 304 Not Modified responses have their body cleared unconditionally

Both are applied as post-graph fixups in `ResourceEngine.run()`, consistent with the Allow header injection added in #17.

Closes #13

## RFC references

- RFC 7231 §4.3.2 — HEAD: server MUST NOT send a message body
- RFC 7232 §4.1 — 304: MUST NOT contain a message body
- RFC 9110 §15.3.5 — 204: MUST NOT contain content

## Test plan

- [ ] `ResourceEngineTest.headResponseHasNoBody` — HEAD on default resource → 200, body is null
- [ ] `ResourceEngineTest.notModifiedResponseHasNoBody` — GET with matching ETag → 304, body is null
- [ ] All 32 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)