### PR TITLE
fix: set WWW-Authenticate (401) and Location (3xx) response headers

### DIFF
--- a/src/main/java/kotowari/restful/ResourceEngine.java
+++ b/src/main/java/kotowari/restful/ResourceEngine.java
@@ -144,17 +144,7 @@ public class ResourceEngine {
                         return result;
                     };
                     case MOVED_PERMANENTLY, MOVED_TEMPORARILY, POST_REDIRECT ->
-                        original == null ? null : ctx -> {
-                            Object result = original.apply(ctx);
-                            if (result instanceof String location) {
-                                ctx.addHeader("Location", location);
-                                return true;
-                            } else if (result instanceof URI uri) {
-                                ctx.addHeader("Location", uri.toString());
-                                return true;
-                            }
-                            return result;
-                        };
+                        original == null ? null : redirectHandler(original);
                     default -> original;
                 };
             }
@@ -163,6 +153,22 @@ public class ResourceEngine {
             public Set<String> getAllowedMethods() {
                 return resource.getAllowedMethods();
             }
+        };
+    }
+
+    private static Function<RestContext, ?> redirectHandler(Function<RestContext, ?> original) {
+        return ctx -> {
+            Object result = original.apply(ctx);
+            String location = switch (result) {
+                case String s -> s;
+                case URI uri -> uri.toString();
+                default -> null;
+            };
+            if (location != null) {
+                ctx.addHeader("Location", location);
+                return true;
+            }
+            return result;
         };
     }
 

--- a/src/main/java/kotowari/restful/ResourceEngine.java
+++ b/src/main/java/kotowari/restful/ResourceEngine.java
@@ -112,20 +112,6 @@ public class ResourceEngine {
     }
 
     /**
-     * Creates a decision node for redirect decisions ({@code MOVED_PERMANENTLY},
-     * {@code MOVED_TEMPORARILY}, {@code POST_REDIRECT}).
-     *
-     * <p>When the resource function returns a {@link String} or {@link URI}, the value
-     * is set as the {@code Location} response header and the decision is truthy.
-     * This satisfies RFC 7231 §6.4 which requires a {@code Location} header on all
-     * 3xx redirect responses.
-     *
-     * @param point     the redirect decision point
-     * @param thenNode  the handler to route to when the decision is truthy (redirect)
-     * @param elseNode  the node to route to when the decision is falsy (no redirect)
-     * @return a new {@link Decision} that extracts the Location header from the return value
-     */
-    /**
      * Wraps a resource so that:
      * <ul>
      *   <li>{@code AUTHORIZED} — when the resource function returns a {@link String},
@@ -137,35 +123,46 @@ public class ResourceEngine {
      *       {@code true} (routes to the redirect handler), satisfying RFC 7231 §6.4.</li>
      * </ul>
      *
+     * <p>{@link Resource#getAllowedMethods()} is delegated to the original resource
+     * so that {@code ClassResource} overrides are preserved.
+     *
      * @param resource the original resource
      * @return a wrapped resource with header-aware function overrides
      */
     private static Resource wrapResource(Resource resource) {
-        return point -> {
-            Function<RestContext, ?> original = resource.getFunction(point);
-            return switch (point) {
-                case AUTHORIZED -> original == null ? null : ctx -> {
-                    Object result = original.apply(ctx);
-                    if (result instanceof String challenge) {
-                        ctx.addHeader("WWW-Authenticate", challenge);
-                        return false;
-                    }
-                    return result;
-                };
-                case MOVED_PERMANENTLY, MOVED_TEMPORARILY, POST_REDIRECT ->
-                    original == null ? null : ctx -> {
+        return new Resource() {
+            @Override
+            public Function<RestContext, ?> getFunction(DecisionPoint point) {
+                Function<RestContext, ?> original = resource.getFunction(point);
+                return switch (point) {
+                    case AUTHORIZED -> original == null ? null : ctx -> {
                         Object result = original.apply(ctx);
-                        if (result instanceof String location) {
-                            ctx.addHeader("Location", location);
-                            return true;
-                        } else if (result instanceof URI uri) {
-                            ctx.addHeader("Location", uri.toString());
-                            return true;
+                        if (result instanceof String challenge) {
+                            ctx.addHeader("WWW-Authenticate", challenge);
+                            return false;
                         }
                         return result;
                     };
-                default -> original;
-            };
+                    case MOVED_PERMANENTLY, MOVED_TEMPORARILY, POST_REDIRECT ->
+                        original == null ? null : ctx -> {
+                            Object result = original.apply(ctx);
+                            if (result instanceof String location) {
+                                ctx.addHeader("Location", location);
+                                return true;
+                            } else if (result instanceof URI uri) {
+                                ctx.addHeader("Location", uri.toString());
+                                return true;
+                            }
+                            return result;
+                        };
+                    default -> original;
+                };
+            }
+
+            @Override
+            public Set<String> getAllowedMethods() {
+                return resource.getAllowedMethods();
+            }
         };
     }
 

--- a/src/main/java/kotowari/restful/ResourceEngine.java
+++ b/src/main/java/kotowari/restful/ResourceEngine.java
@@ -15,6 +15,7 @@ import kotowari.restful.decision.Node;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.net.URI;
 import java.util.Objects;
 import java.util.Set;
 import java.util.StringJoiner;
@@ -98,7 +99,7 @@ public class ResourceEngine {
      * @return API response
      */
     public ApiResponse run(Resource resource, HttpRequest request) {
-        RestContext context = new RestContext(resource, request);
+        RestContext context = new RestContext(wrapResource(resource), request);
         ApiResponse response = runDecisionGraph(context);
         int status = response.getStatus();
         if (status == 405 || ("OPTIONS".equalsIgnoreCase(request.getRequestMethod()) && status >= 200 && status < 300)) {
@@ -108,6 +109,64 @@ public class ResourceEngine {
             response.setBody(null);
         }
         return response;
+    }
+
+    /**
+     * Creates a decision node for redirect decisions ({@code MOVED_PERMANENTLY},
+     * {@code MOVED_TEMPORARILY}, {@code POST_REDIRECT}).
+     *
+     * <p>When the resource function returns a {@link String} or {@link URI}, the value
+     * is set as the {@code Location} response header and the decision is truthy.
+     * This satisfies RFC 7231 §6.4 which requires a {@code Location} header on all
+     * 3xx redirect responses.
+     *
+     * @param point     the redirect decision point
+     * @param thenNode  the handler to route to when the decision is truthy (redirect)
+     * @param elseNode  the node to route to when the decision is falsy (no redirect)
+     * @return a new {@link Decision} that extracts the Location header from the return value
+     */
+    /**
+     * Wraps a resource so that:
+     * <ul>
+     *   <li>{@code AUTHORIZED} — when the resource function returns a {@link String},
+     *       it is used as the {@code WWW-Authenticate} header value and the result is
+     *       changed to {@code false} (routes to 401), satisfying RFC 7235 §4.1.</li>
+     *   <li>{@code MOVED_PERMANENTLY}, {@code MOVED_TEMPORARILY}, {@code POST_REDIRECT}
+     *       — when the resource function returns a {@link String} or {@link URI},
+     *       it is set as the {@code Location} header and the result is changed to
+     *       {@code true} (routes to the redirect handler), satisfying RFC 7231 §6.4.</li>
+     * </ul>
+     *
+     * @param resource the original resource
+     * @return a wrapped resource with header-aware function overrides
+     */
+    private static Resource wrapResource(Resource resource) {
+        return point -> {
+            Function<RestContext, ?> original = resource.getFunction(point);
+            return switch (point) {
+                case AUTHORIZED -> original == null ? null : ctx -> {
+                    Object result = original.apply(ctx);
+                    if (result instanceof String challenge) {
+                        ctx.addHeader("WWW-Authenticate", challenge);
+                        return false;
+                    }
+                    return result;
+                };
+                case MOVED_PERMANENTLY, MOVED_TEMPORARILY, POST_REDIRECT ->
+                    original == null ? null : ctx -> {
+                        Object result = original.apply(ctx);
+                        if (result instanceof String location) {
+                            ctx.addHeader("Location", location);
+                            return true;
+                        } else if (result instanceof URI uri) {
+                            ctx.addHeader("Location", uri.toString());
+                            return true;
+                        }
+                        return result;
+                    };
+                default -> original;
+            };
+        };
     }
 
     private static String allowHeaderValue(Set<String> methods) {

--- a/src/main/java/kotowari/restful/data/RestContext.java
+++ b/src/main/java/kotowari/restful/data/RestContext.java
@@ -100,6 +100,23 @@ public class RestContext {
         this.headers = headers;
     }
 
+    /**
+     * Adds a single response header to the context.
+     *
+     * <p>If no headers object has been set yet, one is created automatically.
+     * This is the preferred way for decision functions to set individual response
+     * headers such as {@code WWW-Authenticate} or {@code Location}.
+     *
+     * @param name  the header name (case-insensitive per HTTP spec)
+     * @param value the header value
+     */
+    public void addHeader(String name, String value) {
+        if (headers == null) {
+            headers = Headers.empty();
+        }
+        headers.put(name, value);
+    }
+
     public Throwable getException() {
         return exception;
     }

--- a/src/test/java/kotowari/restful/ResourceEngineTest.java
+++ b/src/test/java/kotowari/restful/ResourceEngineTest.java
@@ -221,4 +221,99 @@ class ResourceEngineTest {
         assertThat(response.getStatus()).isEqualTo(301);
         assertThat(response.getHeaders().get("Location")).isEqualTo("/new-location");
     }
+
+    @Test
+    void movedPermanentlyWithUriSetsLocationHeader() {
+        // MOVED_PERMANENTLY returns a URI → 301 with Location header
+        DefaultResource resource = new DefaultResource() {
+            @Override
+            public java.util.function.Function<kotowari.restful.data.RestContext, ?> getFunction(kotowari.restful.DecisionPoint point) {
+                if (point == kotowari.restful.DecisionPoint.EXISTS) {
+                    return ctx -> false;
+                }
+                if (point == kotowari.restful.DecisionPoint.EXISTED) {
+                    return ctx -> true;
+                }
+                if (point == kotowari.restful.DecisionPoint.MOVED_PERMANENTLY) {
+                    return ctx -> java.net.URI.create("/new-location");
+                }
+                return super.getFunction(point);
+            }
+        };
+        HttpRequest request = builder(new DefaultHttpRequest())
+                .set(HttpRequest::setRequestMethod, "GET")
+                .set(HttpRequest::setContentType, "application/json")
+                .set(HttpRequest::setHeaders, Headers.empty())
+                .build();
+
+        ApiResponse response = resourceEngine.run(resource, request);
+
+        assertThat(response.getStatus()).isEqualTo(301);
+        assertThat(response.getHeaders().get("Location")).isEqualTo("/new-location");
+    }
+
+    @Test
+    void movedTemporarilySetsLocationHeader() {
+        // MOVED_TEMPORARILY returns a location string → 307 with Location header
+        DefaultResource resource = new DefaultResource() {
+            @Override
+            public java.util.function.Function<kotowari.restful.data.RestContext, ?> getFunction(kotowari.restful.DecisionPoint point) {
+                if (point == kotowari.restful.DecisionPoint.EXISTS) {
+                    return ctx -> false;
+                }
+                if (point == kotowari.restful.DecisionPoint.EXISTED) {
+                    return ctx -> true;
+                }
+                if (point == kotowari.restful.DecisionPoint.MOVED_PERMANENTLY) {
+                    return ctx -> false;
+                }
+                if (point == kotowari.restful.DecisionPoint.MOVED_TEMPORARILY) {
+                    return ctx -> "/temp-location";
+                }
+                return super.getFunction(point);
+            }
+        };
+        HttpRequest request = builder(new DefaultHttpRequest())
+                .set(HttpRequest::setRequestMethod, "GET")
+                .set(HttpRequest::setContentType, "application/json")
+                .set(HttpRequest::setHeaders, Headers.empty())
+                .build();
+
+        ApiResponse response = resourceEngine.run(resource, request);
+
+        assertThat(response.getStatus()).isEqualTo(307);
+        assertThat(response.getHeaders().get("Location")).isEqualTo("/temp-location");
+    }
+
+    @Test
+    void postRedirectSetsLocationHeader() {
+        // POST_REDIRECT returns a location string → 303 See Other with Location header
+        DefaultResource resource = new DefaultResource() {
+            @Override
+            public Set<String> getAllowedMethods() {
+                return Set.of("GET", "HEAD", "POST");
+            }
+
+            @Override
+            public java.util.function.Function<kotowari.restful.data.RestContext, ?> getFunction(kotowari.restful.DecisionPoint point) {
+                if (point == kotowari.restful.DecisionPoint.METHOD_ALLOWED) {
+                    return DefaultResource.testRequestMethod("GET", "HEAD", "POST");
+                }
+                if (point == kotowari.restful.DecisionPoint.POST_REDIRECT) {
+                    return ctx -> "/created-resource";
+                }
+                return super.getFunction(point);
+            }
+        };
+        HttpRequest request = builder(new DefaultHttpRequest())
+                .set(HttpRequest::setRequestMethod, "POST")
+                .set(HttpRequest::setContentType, "application/json")
+                .set(HttpRequest::setHeaders, Headers.empty())
+                .build();
+
+        ApiResponse response = resourceEngine.run(resource, request);
+
+        assertThat(response.getStatus()).isEqualTo(303);
+        assertThat(response.getHeaders().get("Location")).isEqualTo("/created-resource");
+    }
 }

--- a/src/test/java/kotowari/restful/ResourceEngineTest.java
+++ b/src/test/java/kotowari/restful/ResourceEngineTest.java
@@ -167,4 +167,58 @@ class ResourceEngineTest {
         assertThat(response.getStatus()).isEqualTo(204);
         assertThat(response.getBody()).isNull();
     }
+
+    @Test
+    void unauthorizedSetsWwwAuthenticateHeader() {
+        // AUTHORIZED returns a WWW-Authenticate challenge string → 401 with header
+        DefaultResource resource = new DefaultResource() {
+            @Override
+            public java.util.function.Function<kotowari.restful.data.RestContext, ?> getFunction(kotowari.restful.DecisionPoint point) {
+                if (point == kotowari.restful.DecisionPoint.AUTHORIZED) {
+                    return ctx -> "Bearer realm=\"api\"";
+                }
+                return super.getFunction(point);
+            }
+        };
+        HttpRequest request = builder(new DefaultHttpRequest())
+                .set(HttpRequest::setRequestMethod, "GET")
+                .set(HttpRequest::setContentType, "application/json")
+                .set(HttpRequest::setHeaders, Headers.empty())
+                .build();
+
+        ApiResponse response = resourceEngine.run(resource, request);
+
+        assertThat(response.getStatus()).isEqualTo(401);
+        assertThat(response.getHeaders().get("WWW-Authenticate")).isEqualTo("Bearer realm=\"api\"");
+    }
+
+    @Test
+    void movedPermanentlySetsLocationHeader() {
+        // MOVED_PERMANENTLY returns a location string → 301 with Location header
+        DefaultResource resource = new DefaultResource() {
+            @Override
+            public java.util.function.Function<kotowari.restful.data.RestContext, ?> getFunction(kotowari.restful.DecisionPoint point) {
+                if (point == kotowari.restful.DecisionPoint.EXISTS) {
+                    return ctx -> false;
+                }
+                if (point == kotowari.restful.DecisionPoint.EXISTED) {
+                    return ctx -> true;
+                }
+                if (point == kotowari.restful.DecisionPoint.MOVED_PERMANENTLY) {
+                    return ctx -> "/new-location";
+                }
+                return super.getFunction(point);
+            }
+        };
+        HttpRequest request = builder(new DefaultHttpRequest())
+                .set(HttpRequest::setRequestMethod, "GET")
+                .set(HttpRequest::setContentType, "application/json")
+                .set(HttpRequest::setHeaders, Headers.empty())
+                .build();
+
+        ApiResponse response = resourceEngine.run(resource, request);
+
+        assertThat(response.getStatus()).isEqualTo(301);
+        assertThat(response.getHeaders().get("Location")).isEqualTo("/new-location");
+    }
 }


### PR DESCRIPTION
## Summary

- Add `RestContext#addHeader(String, String)` for setting individual response headers from decision functions
- Wrap the resource in `ResourceEngine#run()` via `wrapResource()` so that return values from specific decision functions are used to set response headers automatically:
  - `AUTHORIZED` returning a `String` → sets `WWW-Authenticate` header and routes to 401 (RFC 7235 §4.1)
  - `MOVED_PERMANENTLY`, `MOVED_TEMPORARILY`, `POST_REDIRECT` returning a `String` or `URI` → sets `Location` header and routes to the redirect handler (RFC 7231 §6.4)

### Usage example

```java
@Decision(AUTHORIZED)
public Object authorize(HttpRequest request) {
    if (!isAuthenticated(request)) {
        return "Bearer realm=\"api\"";  // → 401 + WWW-Authenticate: Bearer realm="api"
    }
    return true;
}

@Decision(MOVED_PERMANENTLY)
public String movedPermanently() {
    return "/new-path";  // → 301 + Location: /new-path
}
```

Closes #15

## RFC references

- RFC 7235 §4.1 — 401 MUST include `WWW-Authenticate`
- RFC 7231 §6.4 — 3xx responses MUST include `Location`

## Test plan

- [ ] `unauthorizedSetsWwwAuthenticateHeader` — AUTHORIZED returns `String` → 401 with `WWW-Authenticate`
- [ ] `movedPermanentlySetsLocationHeader` — MOVED_PERMANENTLY returns `String` → 301 with `Location`
- [ ] All 35 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)