### PR TITLE
feat: upgrade to enkan 0.14.0 and raoh 0.4.1

### DIFF
--- a/example/pom.xml
+++ b/example/pom.xml
@@ -5,17 +5,17 @@
 
     <groupId>net.unit8.enkan</groupId>
     <artifactId>kotowari-restful-example</artifactId>
-    <version>0.13.0-SNAPSHOT</version>
+    <version>0.14.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>kotowari-restful-example</name>
     <description>Example application for kotowari-restful</description>
 
     <properties>
         <java.version>25</java.version>
-        <enkan.version>0.13.0</enkan.version>
+        <enkan.version>0.14.0</enkan.version>
         <jackson.version>3.1.0</jackson.version>
         <jackson.jaxrs.version>3.1.0</jackson.jaxrs.version>
-        <raoh.version>0.3.0</raoh.version>
+        <raoh.version>0.4.1</raoh.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/example/src/main/java/kotowari/restful/example/dao/CustomerMapper.java
+++ b/example/src/main/java/kotowari/restful/example/dao/CustomerMapper.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static net.unit8.raoh.ObjectDecoders.*;
 import static net.unit8.raoh.jooq.JooqRecordDecoders.*;
 
 /**
@@ -86,7 +87,7 @@ public class CustomerMapper {
             field("first_name", STRING50),
             field("middle_name", nullable(STRING50)).map(Optional::ofNullable),
             field("last_name", STRING100)
-    ).apply(PersonalName::new)::decode;
+    ).map(PersonalName::new)::decode;
 
     /**
      * Builds an {@link EmailContactInfo} from the {@code label} and
@@ -95,7 +96,7 @@ public class CustomerMapper {
     private static final JooqRecordDecoder<EmailContactInfo> EMAIL_CONTACT_DECODER = combine(
             field("label", STRING50),
             field("email_address", EMAIL_ADDR)
-    ).apply(EmailContactInfo::new)::decode;
+    ).map(EmailContactInfo::new)::decode;
 
     /**
      * Builds a {@link PostalContactInfo} from the {@code label}, {@code address1}
@@ -110,7 +111,7 @@ public class CustomerMapper {
             field("city", STRING50),
             field("state", STRING50),
             field("zip_code", ZIP)
-    ).apply(PostalContactInfo::new)::decode;
+    ).map(PostalContactInfo::new)::decode;
 
     // ========================================================================
     // Discriminating decoder — dispatches on the type column
@@ -165,7 +166,7 @@ public class CustomerMapper {
      * into a single decoder that reads both from the same {@link Record}.
      */
     private static final JooqRecordDecoder<TaggedContact> TAGGED_CONTACT_DECODER =
-            combine(CONTACT_METHOD_DECODER, IS_PRIMARY_DECODER).apply(TaggedContact::new)::decode;
+            combine(CONTACT_METHOD_DECODER, IS_PRIMARY_DECODER).map(TaggedContact::new)::decode;
 
     /** Decodes the {@code id} column as a long. */
     private static final JooqRecordDecoder<Long> ID_DECODER = field("id", long_());
@@ -176,7 +177,7 @@ public class CustomerMapper {
      * the same {@link Record}.
      */
     private static final JooqRecordDecoder<TaggedContactWithId> TAGGED_CONTACT_WITH_ID_DECODER =
-            combine(ID_DECODER, CONTACT_METHOD_DECODER, IS_PRIMARY_DECODER).apply(TaggedContactWithId::new)::decode;
+            combine(ID_DECODER, CONTACT_METHOD_DECODER, IS_PRIMARY_DECODER).map(TaggedContactWithId::new)::decode;
 
     /**
      * Partitions a list of contact_method rows into one primary and zero or more

--- a/example/src/main/java/kotowari/restful/example/resource/CustomerJsonDecoders.java
+++ b/example/src/main/java/kotowari/restful/example/resource/CustomerJsonDecoders.java
@@ -65,12 +65,12 @@ public final class CustomerJsonDecoders {
             field("firstName", STRING50),
             optionalField("middleName", STRING50),
             field("lastName", STRING100)
-    ).apply(PersonalName::new)::decode;
+    ).map(PersonalName::new)::decode;
 
     static final JsonDecoder<EmailContactInfo> EMAIL_CONTACT_INFO = combine(
             field("label", STRING50),
             field("emailAddress", EMAIL_ADDRESS)
-    ).apply(EmailContactInfo::new)::decode;
+    ).map(EmailContactInfo::new)::decode;
 
     static final JsonDecoder<PostalContactInfo> POSTAL_CONTACT_INFO = combine(
             field("label", STRING50),
@@ -79,7 +79,7 @@ public final class CustomerJsonDecoders {
             field("city", STRING50),
             field("state", STRING50),
             field("zipCode", ZIP_CODE)
-    ).apply(PostalContactInfo::new)::decode;
+    ).map(PostalContactInfo::new)::decode;
 
     // ========================================================================
     // Discriminating decoder for ContactMethod
@@ -104,5 +104,5 @@ public final class CustomerJsonDecoders {
             field("name", PERSONAL_NAME),
             field("primaryContactMethod", CONTACT_METHOD),
             field("secondaryContactMethods", list(CONTACT_METHOD))
-    ).apply(Customer::new)::decode;
+    ).map(Customer::new)::decode;
 }

--- a/kotowari-restful-devel/pom.xml
+++ b/kotowari-restful-devel/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>net.unit8.enkan</groupId>
         <artifactId>kotowari-restful-parent</artifactId>
-        <version>0.13.1-SNAPSHOT</version>
+        <version>0.14.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kotowari-restful-devel</artifactId>

--- a/kotowari-restful/pom.xml
+++ b/kotowari-restful/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>net.unit8.enkan</groupId>
         <artifactId>kotowari-restful-parent</artifactId>
-        <version>0.13.1-SNAPSHOT</version>
+        <version>0.14.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kotowari-restful</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,13 +5,13 @@
     <parent>
         <groupId>net.unit8.enkan</groupId>
         <artifactId>enkan-parent</artifactId>
-        <version>0.13.1-SNAPSHOT</version>
+        <version>0.14.0</version>
     </parent>
 
     <artifactId>kotowari-restful-parent</artifactId>
     <packaging>pom</packaging>
     <name>kotowari-restful-parent</name>
-    <version>0.13.1-SNAPSHOT</version>
+    <version>0.14.0-SNAPSHOT</version>
     <description>Kotowari-Restful is a RESTful API specific framework.</description>
 
     <modules>


### PR DESCRIPTION
## Summary

- Bump `enkan-parent` from `0.13.1-SNAPSHOT` to `0.14.0`
- Bump project version to `0.14.0-SNAPSHOT`
- Bump `raoh` from `0.3.0` to `0.4.1`
- Migrate `Combiner.apply()` to `.map()` (raoh 0.4.1 API rename)
- Add missing `ObjectDecoders.*` static import in `CustomerMapper`

## Test plan

- [x] `mvn compile` passes for root and all submodules
- [ ] `cd example && mvn compile` (requires remaining enkan 0.14.0 artifacts to be available locally or in Central)

🤖 Generated with [Claude Code](https://claude.com/claude-code)