### PR TITLE
fix: strip prohibited headers from 304 responses (RFC 9110 §15.4.5)

### DIFF
--- a/kotowari-restful/src/main/java/kotowari/restful/ResourceEngine.java
+++ b/kotowari-restful/src/main/java/kotowari/restful/ResourceEngine.java
@@ -49,7 +49,7 @@ import static kotowari.restful.decision.DecisionFactory.*;
  *   <li>405 and successful OPTIONS responses receive an {@code Allow} header
  *       (RFC 7231 §6.5.5, RFC 9110 §9.3.7).</li>
  *   <li>HEAD responses and 204/304 responses have their body cleared
- *       (RFC 7231 §4.3.2, RFC 7232 §4.1, RFC 9110 §15.3.5).</li>
+ *       (RFC 7231 §4.3.2, RFC 7232 §4.1, RFC 9110 §§15.3.5, 15.4.5).</li>
  *   <li>304 responses have {@code Content-Length}, {@code Content-Range}, and
  *       {@code Trailer} headers removed (RFC 9110 §15.4.5).</li>
  * </ul>

--- a/kotowari-restful/src/main/java/kotowari/restful/ResourceEngine.java
+++ b/kotowari-restful/src/main/java/kotowari/restful/ResourceEngine.java
@@ -50,6 +50,8 @@ import static kotowari.restful.decision.DecisionFactory.*;
  *       (RFC 7231 §6.5.5, RFC 9110 §9.3.7).</li>
  *   <li>HEAD responses and 204/304 responses have their body cleared
  *       (RFC 7231 §4.3.2, RFC 7232 §4.1, RFC 9110 §15.3.5).</li>
+ *   <li>304 responses have {@code Content-Length}, {@code Content-Range}, and
+ *       {@code Trailer} headers removed (RFC 9110 §15.4.5).</li>
  * </ul>
  *
  * @author kawasima
@@ -115,6 +117,12 @@ public class ResourceEngine {
         }
         if ("HEAD".equalsIgnoreCase(request.getRequestMethod()) || status == 204 || status == 304) {
             response.setBody(null);
+        }
+        // RFC 9110 §15.4.5: 304 MUST NOT contain Content-Length, Content-Range, or Trailer.
+        if (status == 304) {
+            response.getHeaders().remove("Content-Length");
+            response.getHeaders().remove("Content-Range");
+            response.getHeaders().remove("Trailer");
         }
         if (tracingEnabled) {
             String traceId = UUID.randomUUID().toString().replace("-", "").substring(0, 8);

--- a/kotowari-restful/src/test/java/kotowari/restful/ResourceEngineTest.java
+++ b/kotowari-restful/src/test/java/kotowari/restful/ResourceEngineTest.java
@@ -143,6 +143,49 @@ class ResourceEngineTest {
     }
 
     @Test
+    void notModifiedResponseStripsProhibitedHeaders() {
+        // RFC 9110 §15.4.5: 304 MUST NOT contain Content-Length, Content-Range, or Trailer.
+        DefaultResource resource = new DefaultResource() {
+            @Override
+            public java.util.function.Function<kotowari.restful.data.RestContext, ?> getFunction(kotowari.restful.DecisionPoint point) {
+                if (point == kotowari.restful.DecisionPoint.IF_NONE_MATCH_EXISTS) {
+                    return ctx -> true;
+                }
+                if (point == kotowari.restful.DecisionPoint.IF_NONE_MATCH_STAR) {
+                    return ctx -> false;
+                }
+                if (point == kotowari.restful.DecisionPoint.ETAG_MATCHES_FOR_IF_NONE) {
+                    return ctx -> true;
+                }
+                if (point == kotowari.restful.DecisionPoint.HANDLE_NOT_MODIFIED) {
+                    return ctx -> {
+                        ctx.addHeader("Content-Length", "42");
+                        ctx.addHeader("Content-Range", "bytes 0-41/42");
+                        ctx.addHeader("Trailer", "Expires");
+                        ctx.addHeader("ETag", "\"abc\""); // allowed — should survive
+                        return "body";
+                    };
+                }
+                return super.getFunction(point);
+            }
+        };
+        HttpRequest request = builder(new DefaultHttpRequest())
+                .set(HttpRequest::setRequestMethod, "GET")
+                .set(HttpRequest::setContentType, "application/json")
+                .set(HttpRequest::setHeaders, Headers.of("if-none-match", "\"abc\""))
+                .build();
+
+        ApiResponse response = resourceEngine.run(resource, request);
+
+        assertThat(response.getStatus()).isEqualTo(304);
+        assertThat(response.getBody()).isNull();
+        assertThat(response.getHeaders().get("Content-Length")).isNull();
+        assertThat(response.getHeaders().get("Content-Range")).isNull();
+        assertThat(response.getHeaders().get("Trailer")).isNull();
+        assertThat(response.getHeaders().get("ETag")).isEqualTo("\"abc\"");
+    }
+
+    @Test
     void noContentResponseHasNoBody() {
         // Resource that returns 204 by responding with entity=false after DELETE.
         // HANDLE_NO_CONTENT is overridden to return a non-null body, proving the fixup strips it.


### PR DESCRIPTION
## Summary

Closes #21.

RFC 9110 §15.4.5 states that a 304 response **MUST NOT** contain `Content-Length`, `Content-Range`, or `Trailer` headers. The body was already being stripped, but these headers could leak through from upstream middleware (e.g. `SerDesMiddleware`) or handler overrides.

## Changes

### `ResourceEngine.run()`
Added explicit header removal after body-stripping for `status == 304`:
```java
if (status == 304) {
    response.getHeaders().remove("Content-Length");
    response.getHeaders().remove("Content-Range");
    response.getHeaders().remove("Trailer");
}
```

HEAD and 204 responses are unaffected — `Content-Length` is allowed for 204 per RFC 9110 §8.6.

## Test plan

- [x] New test `notModifiedResponseStripsProhibitedHeaders`: sets `Content-Length`, `Content-Range`, `Trailer`, and `ETag` in a 304 handler override; verifies prohibited headers are removed while `ETag` survives
- [x] Existing `notModifiedResponseHasNoBody` continues to pass
- [x] `mvn test` passes all modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)