### PR TITLE
feat: set Vary header for content negotiation (RFC 7231 §7.1.4)

### DIFF
--- a/kotowari-restful/src/main/java/kotowari/restful/ResourceEngine.java
+++ b/kotowari-restful/src/main/java/kotowari/restful/ResourceEngine.java
@@ -18,6 +18,7 @@ import org.slf4j.LoggerFactory;
 import kotowari.restful.trace.TraceStore;
 
 import java.net.URI;
+import java.util.LinkedHashSet;
 import java.util.Objects;
 import java.util.Set;
 import java.util.StringJoiner;
@@ -128,13 +129,23 @@ public class ResourceEngine {
             response.getHeaders().remove("Trailer");
         }
         // RFC 7231 §7.1.4: set Vary when content negotiation headers are present.
-        StringJoiner vary = new StringJoiner(", ");
-        if (request.getHeaders().containsKey("accept"))          vary.add("Accept");
-        if (request.getHeaders().containsKey("accept-language")) vary.add("Accept-Language");
-        if (request.getHeaders().containsKey("accept-charset"))  vary.add("Accept-Charset");
-        if (request.getHeaders().containsKey("accept-encoding")) vary.add("Accept-Encoding");
-        if (vary.length() > 0) {
-            response.getHeaders().put("Vary", vary.toString());
+        // Merge with any existing Vary value set by the resource; preserve "Vary: *".
+        String existingVary = (String) response.getHeaders().get("Vary");
+        if (!"*".equals(existingVary)) {
+            Set<String> varyTokens = new LinkedHashSet<>();
+            if (existingVary != null) {
+                for (String token : existingVary.split(",")) {
+                    varyTokens.add(token.strip());
+                }
+            }
+            if (request.getHeaders().containsKey("accept"))          varyTokens.add("Accept");
+            if (request.getHeaders().containsKey("accept-language")) varyTokens.add("Accept-Language");
+            if (request.getHeaders().containsKey("accept-charset"))  varyTokens.add("Accept-Charset");
+            if (request.getHeaders().containsKey("accept-encoding")) varyTokens.add("Accept-Encoding");
+            if (!varyTokens.isEmpty()) {
+                response.getHeaders().remove("Vary");
+                response.getHeaders().put("Vary", String.join(", ", varyTokens));
+            }
         }
         if (tracingEnabled) {
             String traceId = UUID.randomUUID().toString().replace("-", "").substring(0, 8);

--- a/kotowari-restful/src/main/java/kotowari/restful/ResourceEngine.java
+++ b/kotowari-restful/src/main/java/kotowari/restful/ResourceEngine.java
@@ -52,6 +52,9 @@ import static kotowari.restful.decision.DecisionFactory.*;
  *       (RFC 7231 §4.3.2, RFC 7232 §4.1, RFC 9110 §§15.3.5, 15.4.5).</li>
  *   <li>304 responses have {@code Content-Length}, {@code Content-Range}, and
  *       {@code Trailer} headers removed (RFC 9110 §15.4.5).</li>
+ *   <li>A {@code Vary} header is set when content negotiation headers
+ *       ({@code Accept}, {@code Accept-Language}, {@code Accept-Charset},
+ *       {@code Accept-Encoding}) are present in the request (RFC 7231 §7.1.4).</li>
  * </ul>
  *
  * @author kawasima
@@ -123,6 +126,15 @@ public class ResourceEngine {
             response.getHeaders().remove("Content-Length");
             response.getHeaders().remove("Content-Range");
             response.getHeaders().remove("Trailer");
+        }
+        // RFC 7231 §7.1.4: set Vary when content negotiation headers are present.
+        StringJoiner vary = new StringJoiner(", ");
+        if (request.getHeaders().containsKey("accept"))          vary.add("Accept");
+        if (request.getHeaders().containsKey("accept-language")) vary.add("Accept-Language");
+        if (request.getHeaders().containsKey("accept-charset"))  vary.add("Accept-Charset");
+        if (request.getHeaders().containsKey("accept-encoding")) vary.add("Accept-Encoding");
+        if (vary.length() > 0) {
+            response.getHeaders().put("Vary", vary.toString());
         }
         if (tracingEnabled) {
             String traceId = UUID.randomUUID().toString().replace("-", "").substring(0, 8);

--- a/kotowari-restful/src/test/java/kotowari/restful/ResourceEngineTest.java
+++ b/kotowari-restful/src/test/java/kotowari/restful/ResourceEngineTest.java
@@ -496,4 +496,47 @@ class ResourceEngineTest {
 
         assertThat(response.getStatus()).isEqualTo(200);
     }
+
+    // ── Vary header tests ─────────────────────────────────────────────────
+
+    @Test
+    void varyHeaderSetWhenAcceptPresent() {
+        HttpRequest request = builder(new DefaultHttpRequest())
+                .set(HttpRequest::setRequestMethod, "GET")
+                .set(HttpRequest::setContentType, "application/json")
+                .set(HttpRequest::setHeaders, Headers.of("accept", "application/json"))
+                .build();
+
+        ApiResponse response = resourceEngine.run(new DefaultResource(), request);
+
+        assertThat(response.getHeaders().get("Vary")).isEqualTo("Accept");
+    }
+
+    @Test
+    void varyHeaderIncludesMultipleNegotiationHeaders() {
+        Headers headers = Headers.of("accept", "application/json",
+                "accept-language", "en");
+        HttpRequest request = builder(new DefaultHttpRequest())
+                .set(HttpRequest::setRequestMethod, "GET")
+                .set(HttpRequest::setContentType, "application/json")
+                .set(HttpRequest::setHeaders, headers)
+                .build();
+
+        ApiResponse response = resourceEngine.run(new DefaultResource(), request);
+
+        assertThat(response.getHeaders().get("Vary")).isEqualTo("Accept, Accept-Language");
+    }
+
+    @Test
+    void varyHeaderAbsentWhenNoNegotiationHeaders() {
+        HttpRequest request = builder(new DefaultHttpRequest())
+                .set(HttpRequest::setRequestMethod, "GET")
+                .set(HttpRequest::setContentType, "application/json")
+                .set(HttpRequest::setHeaders, Headers.empty())
+                .build();
+
+        ApiResponse response = resourceEngine.run(new DefaultResource(), request);
+
+        assertThat(response.getHeaders().get("Vary")).isNull();
+    }
 }

--- a/kotowari-restful/src/test/java/kotowari/restful/ResourceEngineTest.java
+++ b/kotowari-restful/src/test/java/kotowari/restful/ResourceEngineTest.java
@@ -539,4 +539,57 @@ class ResourceEngineTest {
 
         assertThat(response.getHeaders().get("Vary")).isNull();
     }
+
+    @Test
+    void varyHeaderMergesWithExistingValue() {
+        // Resource that pre-sets Vary: Origin
+        DefaultResource resource = new DefaultResource() {
+            @Override
+            public java.util.function.Function<kotowari.restful.data.RestContext, ?> getFunction(DecisionPoint point) {
+                if (point == DecisionPoint.HANDLE_OK) {
+                    return ctx -> {
+                        ctx.addHeader("Vary", "Origin");
+                        return "ok";
+                    };
+                }
+                return super.getFunction(point);
+            }
+        };
+        HttpRequest request = builder(new DefaultHttpRequest())
+                .set(HttpRequest::setRequestMethod, "GET")
+                .set(HttpRequest::setContentType, "application/json")
+                .set(HttpRequest::setHeaders, Headers.of("accept", "application/json"))
+                .build();
+
+        ApiResponse response = resourceEngine.run(resource, request);
+
+        assertThat(response.getHeaders().get("Vary")).isEqualTo("Origin, Accept");
+    }
+
+    @Test
+    void varyStarIsPreserved() {
+        // Resource that pre-sets Vary: *
+        DefaultResource resource = new DefaultResource() {
+            @Override
+            public java.util.function.Function<kotowari.restful.data.RestContext, ?> getFunction(DecisionPoint point) {
+                if (point == DecisionPoint.HANDLE_OK) {
+                    return ctx -> {
+                        ctx.addHeader("Vary", "*");
+                        return "ok";
+                    };
+                }
+                return super.getFunction(point);
+            }
+        };
+        HttpRequest request = builder(new DefaultHttpRequest())
+                .set(HttpRequest::setRequestMethod, "GET")
+                .set(HttpRequest::setContentType, "application/json")
+                .set(HttpRequest::setHeaders, Headers.of("accept", "application/json"))
+                .build();
+
+        ApiResponse response = resourceEngine.run(resource, request);
+
+        // Vary: * must not be overwritten
+        assertThat(response.getHeaders().get("Vary")).isEqualTo("*");
+    }
 }


### PR DESCRIPTION
## Summary

Closes #16.

When content negotiation headers (`Accept`, `Accept-Language`, `Accept-Charset`, `Accept-Encoding`) are present in the request, the `Vary` response header is now set automatically per RFC 7231 §7.1.4.

## Changes

### `ResourceEngine.run()` post-graph fixup

Checks the request for `Accept-*` headers and builds the `Vary` header value:

```java
StringJoiner vary = new StringJoiner(", ");
if (request.getHeaders().containsKey("accept"))          vary.add("Accept");
if (request.getHeaders().containsKey("accept-language")) vary.add("Accept-Language");
if (request.getHeaders().containsKey("accept-charset"))  vary.add("Accept-Charset");
if (request.getHeaders().containsKey("accept-encoding")) vary.add("Accept-Encoding");
if (vary.length() > 0) {
    response.getHeaders().put("Vary", vary.toString());
}
```

No changes to `RestContext` or the decision graph needed — the check is performed directly on the request headers.

## Test plan

- [x] `Accept` only → `Vary: Accept`
- [x] `Accept` + `Accept-Language` → `Vary: Accept, Accept-Language`
- [x] No `Accept-*` headers → no `Vary` header
- [x] `mvn test` passes all modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)