### PR TITLE
refactor: tidy example resources and wire Idempotency-Key middleware

### DIFF
--- a/example/src/main/java/kotowari/restful/example/ExampleApplicationFactory.java
+++ b/example/src/main/java/kotowari/restful/example/ExampleApplicationFactory.java
@@ -6,9 +6,11 @@ import enkan.config.ApplicationFactory;
 import enkan.web.data.HttpRequest;
 import enkan.web.data.HttpResponse;
 import enkan.web.middleware.ContentNegotiationMiddleware;
+import enkan.web.middleware.IdempotencyKeyMiddleware;
 import enkan.web.middleware.MultipartParamsMiddleware;
 import enkan.web.middleware.NestedParamsMiddleware;
 import enkan.web.middleware.ParamsMiddleware;
+import enkan.web.middleware.session.MemoryStore;
 import enkan.middleware.jooq.JooqDslContextMiddleware;
 import enkan.system.inject.ComponentInjector;
 import kotowari.inject.ParameterInjector;
@@ -49,6 +51,7 @@ import static enkan.util.Predicates.envIn;
  *   <li>{@code RoutingMiddleware} — matches the request path and sets the target resource class on the request</li>
  *   <li>{@code JooqDslContextMiddleware} — provides a jOOQ DSLContext on every request</li>
  *   <li>{@code SerDesMiddleware} — deserializes the JSON request body and serializes the response object to JSON</li>
+ *   <li>{@code IdempotencyKeyMiddleware} — replays cached responses for repeated POST/PATCH requests carrying the same {@code Idempotency-Key} header (Zalando §230)</li>
  *   <li>{@code ResourceInvokerMiddleware} — drives the kotowari-restful decision graph and calls the resource class</li>
  * </ol>
  */
@@ -97,6 +100,9 @@ public class ExampleApplicationFactory implements ApplicationFactory<HttpRequest
         app.use(new RoutingMiddleware(routes));
         app.use(new JooqDslContextMiddleware<>());
         app.use(new SerDesMiddleware<>());
+        app.use(builder(new IdempotencyKeyMiddleware())
+                .set(IdempotencyKeyMiddleware::setStore, new MemoryStore())
+                .build());
         app.use(resourceInvoker);
         return app;
     }

--- a/example/src/main/java/kotowari/restful/example/data/CustomerWithIds.java
+++ b/example/src/main/java/kotowari/restful/example/data/CustomerWithIds.java
@@ -1,5 +1,6 @@
 package kotowari.restful.example.data;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -18,4 +19,34 @@ public record CustomerWithIds(
         long primaryCmId,
         List<Map.Entry<Long, ContactMethod>> secondaryCmIds
 ) {
+    /**
+     * Builds a new {@link CustomerWithIds} reflecting a promote-to-primary operation,
+     * preserving the original DB ids of each contact method row.
+     *
+     * <p>The contact method in {@code promoted.primaryContactMethod()} is identified
+     * among the current secondaries by value equality, its DB id becomes the new
+     * primary id, and the old primary is prepended to the remaining secondaries in
+     * their original order.
+     *
+     * @param promoted the new {@link Customer} returned by the promotion behavior
+     * @return a new {@link CustomerWithIds} with updated CM ordering and preserved ids
+     * @throws java.util.NoSuchElementException if the promoted primary is not among the current secondaries
+     */
+    public CustomerWithIds withPromoted(Customer promoted) {
+        ContactMethod newPrimary = promoted.primaryContactMethod();
+        long newPrimaryId = secondaryCmIds.stream()
+                .filter(e -> e.getValue().equals(newPrimary))
+                .mapToLong(Map.Entry::getKey)
+                .findFirst()
+                .orElseThrow();
+
+        List<Map.Entry<Long, ContactMethod>> newSecondaries = new ArrayList<>(secondaryCmIds.size());
+        newSecondaries.add(Map.entry(primaryCmId, customer.primaryContactMethod()));
+        for (Map.Entry<Long, ContactMethod> e : secondaryCmIds) {
+            if (e.getKey() != newPrimaryId) {
+                newSecondaries.add(e);
+            }
+        }
+        return new CustomerWithIds(promoted, newPrimaryId, List.copyOf(newSecondaries));
+    }
 }

--- a/example/src/main/java/kotowari/restful/example/resource/AddressJsonDecoders.java
+++ b/example/src/main/java/kotowari/restful/example/resource/AddressJsonDecoders.java
@@ -1,0 +1,52 @@
+package kotowari.restful.example.resource;
+
+import kotowari.restful.example.data.Address;
+import net.unit8.raoh.json.JsonDecoder;
+
+import static net.unit8.raoh.json.JsonDecoders.*;
+
+/**
+ * JSON decoders for the {@link Address} domain type.
+ *
+ * <p>Centralizes the JSON → {@link Address} boundary so validation rules
+ * (required fields, max lengths, ISO country code format) are declared
+ * once and reused by both the collection and single-item resources.
+ */
+public final class AddressJsonDecoders {
+
+    private AddressJsonDecoders() {}
+
+    private static final JsonDecoder<String> REQUIRED_STRING =
+            string().trim().nonBlank()::decode;
+
+    private static final JsonDecoder<String> OPTIONAL_STRING =
+            string().trim()::decode;
+
+    private static final JsonDecoder<String> COUNTRY_CODE =
+            string().trim().minLength(2).maxLength(2)::decode;
+
+    private static Address build(java.util.Optional<String> careOf,
+                                 String street,
+                                 java.util.Optional<String> additional,
+                                 String city,
+                                 java.util.Optional<String> zip,
+                                 String countryCode) {
+        return new Address(null,
+                careOf.orElse(null),
+                street,
+                additional.orElse(null),
+                city,
+                zip.orElse(null),
+                countryCode);
+    }
+
+    /** Decodes a JSON object into an {@link Address}. The {@code id} field is always {@code null}. */
+    public static final JsonDecoder<Address> ADDRESS = combine(
+            optionalField("careOf", OPTIONAL_STRING),
+            field("street", REQUIRED_STRING),
+            optionalField("additional", OPTIONAL_STRING),
+            field("city", REQUIRED_STRING),
+            optionalField("zip", OPTIONAL_STRING),
+            field("countryCode", COUNTRY_CODE)
+    ).map(AddressJsonDecoders::build)::decode;
+}

--- a/example/src/main/java/kotowari/restful/example/resource/AddressResource.java
+++ b/example/src/main/java/kotowari/restful/example/resource/AddressResource.java
@@ -7,6 +7,11 @@ import kotowari.restful.data.Problem;
 import kotowari.restful.data.RestContext;
 import kotowari.restful.example.data.Address;
 import kotowari.restful.resource.AllowedMethods;
+import net.unit8.raoh.Err;
+import net.unit8.raoh.Ok;
+import tools.jackson.databind.JsonNode;
+
+import java.util.List;
 
 import org.jooq.DSLContext;
 import org.jooq.Record;
@@ -29,10 +34,11 @@ import static org.jooq.impl.DSL.table;
 public class AddressResource {
 
     static final ContextKey<Address> ADDRESS = ContextKey.of(Address.class);
+    static final ContextKey<Address> ADDRESS_BODY = ContextKey.of("addressBody", Address.class);
 
     @Decision(EXISTS)
     public boolean exists(Parameters params, DSLContext dsl, RestContext context) {
-        Long id = Long.valueOf(params.get("id").toString());
+        long id = Long.parseLong(params.get("id"));
         Record rec = dsl.select(ID, CARE_OF, STREET, ADDITIONAL, CITY, ZIP, COUNTRY_CODE)
                 .from(table("address"))
                 .where(ID.eq(id))
@@ -43,17 +49,19 @@ public class AddressResource {
     }
 
     @Decision(value = MALFORMED, method = {"PUT"})
-    public Problem validatePut(Address body) {
-        if (body.street() == null || body.street().isBlank()) {
-            return Problem.valueOf(400, "Street is required");
-        }
-        if (body.city() == null || body.city().isBlank()) {
-            return Problem.valueOf(400, "City is required");
-        }
-        if (body.countryCode() == null || body.countryCode().length() != 2) {
-            return Problem.valueOf(400, "Country code must be 2 characters");
-        }
-        return null;
+    public Problem validatePut(JsonNode body, RestContext context) {
+        return switch (AddressJsonDecoders.ADDRESS.decode(body)) {
+            case Ok<Address> ok -> {
+                context.put(ADDRESS_BODY, ok.value());
+                yield null;
+            }
+            case Err<Address> err -> {
+                List<Problem.Violation> violations = err.issues().asList().stream()
+                        .map(issue -> new Problem.Violation(issue.path().toString(), issue.code(), issue.message()))
+                        .toList();
+                yield Problem.fromViolationList(violations);
+            }
+        };
     }
 
     @Decision(HANDLE_OK)
@@ -62,8 +70,9 @@ public class AddressResource {
     }
 
     @Decision(PUT)
-    public void update(Address body, DSLContext dsl, RestContext context) {
+    public void update(DSLContext dsl, RestContext context) {
         Address address = context.get(ADDRESS).orElseThrow();
+        Address body = context.get(ADDRESS_BODY).orElseThrow();
         dsl.transaction(cfg -> {
             org.jooq.impl.DSL.using(cfg)
                     .update(table("address"))

--- a/example/src/main/java/kotowari/restful/example/resource/AddressesResource.java
+++ b/example/src/main/java/kotowari/restful/example/resource/AddressesResource.java
@@ -9,6 +9,9 @@ import kotowari.restful.resource.AllowedMethods;
 import kotowari.restful.data.Problem;
 import kotowari.restful.data.RestContext;
 import kotowari.restful.example.data.Address;
+import net.unit8.raoh.Err;
+import net.unit8.raoh.Ok;
+import tools.jackson.databind.JsonNode;
 
 import jakarta.inject.Inject;
 import jakarta.validation.ConstraintViolation;
@@ -55,17 +58,19 @@ public class AddressesResource {
     }
 
     @Decision(value = MALFORMED, method={"POST"})
-    public Problem isPostMalformed(Address body) {
-        if (body.street() == null || body.street().isBlank()) {
-            return Problem.valueOf(400, "Street is required");
-        }
-        if (body.city() == null || body.city().isBlank()) {
-            return Problem.valueOf(400, "City is required");
-        }
-        if (body.countryCode() == null || body.countryCode().length() != 2) {
-            return Problem.valueOf(400, "Country code must be 2 characters");
-        }
-        return null;
+    public Problem isPostMalformed(JsonNode body, RestContext context) {
+        return switch (AddressJsonDecoders.ADDRESS.decode(body)) {
+            case Ok<Address> ok -> {
+                context.put(ADDRESS, ok.value());
+                yield null;
+            }
+            case Err<Address> err -> {
+                List<Problem.Violation> violations = err.issues().asList().stream()
+                        .map(issue -> new Problem.Violation(issue.path().toString(), issue.code(), issue.message()))
+                        .toList();
+                yield Problem.fromViolationList(violations);
+            }
+        };
     }
 
     @Decision(HANDLE_OK)
@@ -79,7 +84,8 @@ public class AddressesResource {
     }
 
     @Decision(POST)
-    public boolean create(Address body, DSLContext dsl, RestContext context) {
+    public boolean create(DSLContext dsl, RestContext context) {
+        Address body = context.get(ADDRESS).orElseThrow();
         dsl.transaction(cfg -> {
             var rec = org.jooq.impl.DSL.using(cfg)
                     .insertInto(table("address"),

--- a/example/src/main/java/kotowari/restful/example/resource/ContactMethodPrimaryResource.java
+++ b/example/src/main/java/kotowari/restful/example/resource/ContactMethodPrimaryResource.java
@@ -87,8 +87,7 @@ public class ContactMethodPrimaryResource {
             case Ok<Customer> ok -> {
                 dsl.transaction(cfg -> {
                     CustomerRepository repo = new CustomerRepository(org.jooq.impl.DSL.using(cfg));
-                    CustomerWithIds updatedCwi = buildPromotedWithIds(existing, ok.value());
-                    repo.replaceContactMethodsWithIds(id.value(), updatedCwi);
+                    repo.replaceContactMethodsWithIds(id.value(), existing.withPromoted(ok.value()));
                     CustomerWithIds refreshed = repo.findByIdWithIds(id.value()).orElseThrow();
                     context.put(CUSTOMER_WITH_IDS, refreshed);
                 });
@@ -101,38 +100,6 @@ public class ContactMethodPrimaryResource {
                 yield Problem.fromViolationList(violations);
             }
         };
-    }
-
-    /**
-     * Builds a {@link CustomerWithIds} that reflects the promoted structure while preserving
-     * the original DB ids of each contact method row.
-     *
-     * <p>After {@link PromoteToPrimary} runs:
-     * <ul>
-     *   <li>The new primary CM is the secondary whose CM equals {@code target}.</li>
-     *   <li>The new secondary list starts with the old primary, followed by the remaining
-     *       secondaries in their original order (excluding the promoted one).</li>
-     * </ul>
-     *
-     * @param existing the original {@link CustomerWithIds} with stable DB ids
-     * @param promoted the new {@link Customer} returned by {@link PromoteToPrimary}
-     * @return a new {@link CustomerWithIds} with updated CM ordering and preserved ids
-     */
-    private static CustomerWithIds buildPromotedWithIds(CustomerWithIds existing, Customer promoted) {
-        ContactMethod newPrimary = promoted.primaryContactMethod();
-        long newPrimaryId = existing.secondaryCmIds().stream()
-                .filter(e -> e.getValue().equals(newPrimary))
-                .mapToLong(java.util.Map.Entry::getKey)
-                .findFirst()
-                .orElseThrow();
-
-        java.util.List<java.util.Map.Entry<Long, ContactMethod>> newSecondaries = new java.util.ArrayList<>();
-        newSecondaries.add(java.util.Map.entry(existing.primaryCmId(), existing.customer().primaryContactMethod()));
-        existing.secondaryCmIds().stream()
-                .filter(e -> e.getKey() != newPrimaryId)
-                .forEach(newSecondaries::add);
-
-        return new CustomerWithIds(promoted, newPrimaryId, java.util.List.copyOf(newSecondaries));
     }
 
     /**

--- a/example/src/test/java/kotowari/restful/example/data/CustomerWithIdsTest.java
+++ b/example/src/test/java/kotowari/restful/example/data/CustomerWithIdsTest.java
@@ -1,0 +1,90 @@
+package kotowari.restful.example.data;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class CustomerWithIdsTest {
+
+    private static ContactMethod email(String label, String address) {
+        return new ContactMethod.Email(new EmailContactInfo(new String50(label), new EmailAddress(address)));
+    }
+
+    private static PersonalName name() {
+        return new PersonalName(new String50("Taro"), java.util.Optional.empty(), new String100("Yamada"));
+    }
+
+    @Test
+    void promotesSecondaryToPrimaryPreservingIds() {
+        ContactMethod originalPrimary = email("work", "work@example.com");
+        ContactMethod sec1 = email("home", "home@example.com");
+        ContactMethod sec2 = email("mobile", "mobile@example.com");
+
+        Customer original = new Customer(name(), originalPrimary, List.of(sec1, sec2));
+        CustomerWithIds existing = new CustomerWithIds(
+                original,
+                10L,
+                List.of(Map.entry(20L, sec1), Map.entry(30L, sec2))
+        );
+
+        // Simulated result of PromoteToPrimary: sec1 becomes primary, old primary goes to secondaries
+        Customer promoted = new Customer(name(), sec1, List.of(originalPrimary, sec2));
+
+        CustomerWithIds result = existing.withPromoted(promoted);
+
+        assertThat(result.customer()).isSameAs(promoted);
+        assertThat(result.primaryCmId()).isEqualTo(20L);
+        assertThat(result.secondaryCmIds()).containsExactly(
+                Map.entry(10L, originalPrimary),
+                Map.entry(30L, sec2)
+        );
+    }
+
+    @Test
+    void promotesLastSecondary() {
+        ContactMethod originalPrimary = email("work", "work@example.com");
+        ContactMethod sec1 = email("home", "home@example.com");
+        ContactMethod sec2 = email("mobile", "mobile@example.com");
+
+        Customer original = new Customer(name(), originalPrimary, List.of(sec1, sec2));
+        CustomerWithIds existing = new CustomerWithIds(
+                original,
+                10L,
+                List.of(Map.entry(20L, sec1), Map.entry(30L, sec2))
+        );
+
+        Customer promoted = new Customer(name(), sec2, List.of(originalPrimary, sec1));
+
+        CustomerWithIds result = existing.withPromoted(promoted);
+
+        assertThat(result.primaryCmId()).isEqualTo(30L);
+        assertThat(result.secondaryCmIds()).containsExactly(
+                Map.entry(10L, originalPrimary),
+                Map.entry(20L, sec1)
+        );
+    }
+
+    @Test
+    void throwsWhenPromotedPrimaryNotInSecondaries() {
+        ContactMethod originalPrimary = email("work", "work@example.com");
+        ContactMethod sec1 = email("home", "home@example.com");
+        ContactMethod unknown = email("fax", "fax@example.com");
+
+        Customer original = new Customer(name(), originalPrimary, List.of(sec1));
+        CustomerWithIds existing = new CustomerWithIds(
+                original,
+                10L,
+                List.of(Map.entry(20L, sec1))
+        );
+
+        Customer bogus = new Customer(name(), unknown, List.of(originalPrimary));
+
+        assertThatThrownBy(() -> existing.withPromoted(bogus))
+                .isInstanceOf(NoSuchElementException.class);
+    }
+}

--- a/example/src/test/java/kotowari/restful/example/resource/AddressJsonDecodersTest.java
+++ b/example/src/test/java/kotowari/restful/example/resource/AddressJsonDecodersTest.java
@@ -1,0 +1,128 @@
+package kotowari.restful.example.resource;
+
+import kotowari.restful.example.data.Address;
+import net.unit8.raoh.Err;
+import net.unit8.raoh.Ok;
+import net.unit8.raoh.Result;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AddressJsonDecodersTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private static JsonNode tree(Object body) {
+        return MAPPER.valueToTree(body);
+    }
+
+    private static Map<String, Object> validBody() {
+        Map<String, Object> m = new HashMap<>();
+        m.put("careOf", "c/o Yamada");
+        m.put("street", "1-2-3 Shibuya");
+        m.put("additional", "Apt 101");
+        m.put("city", "Tokyo");
+        m.put("zip", "150-0001");
+        m.put("countryCode", "JP");
+        return m;
+    }
+
+    @Test
+    void decodesValidBody() {
+        Result<Address> result = AddressJsonDecoders.ADDRESS.decode(tree(validBody()));
+
+        assertThat(result).isInstanceOf(Ok.class);
+        Address address = ((Ok<Address>) result).value();
+        assertThat(address.id()).isNull();
+        assertThat(address.careOf()).isEqualTo("c/o Yamada");
+        assertThat(address.street()).isEqualTo("1-2-3 Shibuya");
+        assertThat(address.additional()).isEqualTo("Apt 101");
+        assertThat(address.city()).isEqualTo("Tokyo");
+        assertThat(address.zip()).isEqualTo("150-0001");
+        assertThat(address.countryCode()).isEqualTo("JP");
+    }
+
+    @Test
+    void missingStreetIsRejected() {
+        Map<String, Object> body = validBody();
+        body.remove("street");
+
+        Result<Address> result = AddressJsonDecoders.ADDRESS.decode(tree(body));
+
+        assertThat(result).isInstanceOf(Err.class);
+        Err<Address> err = (Err<Address>) result;
+        assertThat(err.issues().asList())
+                .anyMatch(issue -> issue.path().toString().contains("street"));
+    }
+
+    @Test
+    void blankCityIsRejected() {
+        Map<String, Object> body = validBody();
+        body.put("city", "   ");
+
+        Result<Address> result = AddressJsonDecoders.ADDRESS.decode(tree(body));
+
+        assertThat(result).isInstanceOf(Err.class);
+        Err<Address> err = (Err<Address>) result;
+        assertThat(err.issues().asList())
+                .anyMatch(issue -> issue.path().toString().contains("city"));
+    }
+
+    @Test
+    void countryCodeLongerThanTwoIsRejected() {
+        Map<String, Object> body = validBody();
+        body.put("countryCode", "JPN");
+
+        Result<Address> result = AddressJsonDecoders.ADDRESS.decode(tree(body));
+
+        assertThat(result).isInstanceOf(Err.class);
+        Err<Address> err = (Err<Address>) result;
+        assertThat(err.issues().asList())
+                .anyMatch(issue -> issue.path().toString().contains("countryCode"));
+    }
+
+    @Test
+    void countryCodeShorterThanTwoIsRejected() {
+        Map<String, Object> body = validBody();
+        body.put("countryCode", "J");
+
+        Result<Address> result = AddressJsonDecoders.ADDRESS.decode(tree(body));
+
+        assertThat(result).isInstanceOf(Err.class);
+    }
+
+    @Test
+    void optionalFieldsMayBeOmitted() {
+        Map<String, Object> body = new HashMap<>();
+        body.put("street", "1-2-3 Shibuya");
+        body.put("city", "Tokyo");
+        body.put("countryCode", "JP");
+
+        Result<Address> result = AddressJsonDecoders.ADDRESS.decode(tree(body));
+
+        assertThat(result).isInstanceOf(Ok.class);
+        Address address = ((Ok<Address>) result).value();
+        assertThat(address.careOf()).isNull();
+        assertThat(address.additional()).isNull();
+        assertThat(address.zip()).isNull();
+    }
+
+    @Test
+    void multipleViolationsAccumulated() {
+        Map<String, Object> body = new HashMap<>();
+        body.put("street", "");
+        body.put("city", "");
+        body.put("countryCode", "JPN");
+
+        Result<Address> result = AddressJsonDecoders.ADDRESS.decode(tree(body));
+
+        assertThat(result).isInstanceOf(Err.class);
+        Err<Address> err = (Err<Address>) result;
+        assertThat(err.issues().asList()).hasSizeGreaterThanOrEqualTo(2);
+    }
+}


### PR DESCRIPTION
## Summary
- Unify `Address` request validation on a Raoh decoder (`AddressJsonDecoders`), replacing three copies of hand-rolled null/length checks in `AddressesResource` and `AddressResource`
- Move the promote-to-primary id reshuffling from `ContactMethodPrimaryResource` into a new `CustomerWithIds#withPromoted` method, removing FQCN-laden private helper
- Fix `AddressResource#exists` to use `Long.parseLong` consistent with other resources
- Wire `enkan.web.middleware.IdempotencyKeyMiddleware` (Enkan 0.15.0) with a `MemoryStore` so POST/PATCH in the example honor the `Idempotency-Key` header — complies with [Zalando RESTful Guidelines §230](https://opensource.zalando.com/restful-api-guidelines/#230)
- Add unit tests: `AddressJsonDecodersTest` (7) and `CustomerWithIdsTest` (3)

The refactors came out of a review of "not elegant" spots in the example; the Idempotency-Key wiring came out of a Zalando guidelines gap analysis where it was the only item already solvable without touching kotowari-restful core.

## Test plan
- [x] `cd example && mvn clean test` — 19/19 passing (existing 9 + 10 new)
- [ ] Manual: send two POSTs to `/customers` with the same `Idempotency-Key` and confirm the second returns the cached response

🤖 Generated with [Claude Code](https://claude.com/claude-code)